### PR TITLE
Feature/custom col names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/Normalisation_QCpool.r
+++ b/Normalisation_QCpool.r
@@ -61,7 +61,7 @@ ok_norm=function(qcp,qci,spl,spi,method) {
   ok_norm=ok
 }
 
-plotsituation <- function (x, nbid,outfic="plot_regression.pdf", outres="PreNormSummary.txt",fact="batch",span="none") {
+plotsituation <- function (x, nbid,outfic="plot_regression.pdf", outres="PreNormSummary.txt",fact=args$batch_col_name,span="none") {
     #	Check for all ions in every batch if linear or lo(w)ess correction is possible.
     #	Use ok_norm function and create a file (PreNormSummary.txt) with the error code.
     #	Also create a pdf file with plots of linear and lo(w)ess regression lines.
@@ -70,13 +70,13 @@ plotsituation <- function (x, nbid,outfic="plot_regression.pdf", outres="PreNorm
     #	outfic: name of regression plots pdf file
     #	fact: factor to be used as categorical variable for plots and PCA.  
     indfact	=which(dimnames(x)[[2]]==fact)
-    indtypsamp	=which(dimnames(x)[[2]]=="sampleType") 
-    indbatch	=which(dimnames(x)[[2]]=="batch")
-    indinject	=which(dimnames(x)[[2]]=="injectionOrder")
+    indtypsamp	=which(dimnames(x)[[2]]==args$sample_type_col_name) 
+    indbatch	=which(dimnames(x)[[2]]==args$batch_col_name)
+    indinject	=which(dimnames(x)[[2]]==args$injection_order_col_name)
     lastIon=dim(x)[2]
     nbi=lastIon-nbid # Number of ions = total number of columns - number of identifying columns
-    nbb=length(levels(x$batch)) # Number of batch = number of levels of "batch" comlumn (factor)
-    nbs=length(x$sampleType[x$sampleType=="sample"])# Number of samples = number of rows with "sample" value in sampleType
+    nbb=length(levels(x[[args$batch_col_name]])) # Number of batch = number of levels of "batch" comlumn (factor)
+    nbs=length(x[[args$sample_type_col_name]][x[[args$sample_type_col_name]]=="sample"])# Number of samples = number of rows with "sample" value in sampleType
     pdf(outfic,width=27,height=7*ceiling((nbb+2)/3))
     cat(nbi," ions ",nbb," batch(es) \n")
     cv=data.frame(matrix(0,nrow=nbi,ncol=2))# initialisation de la dataset qui contiendra les CV
@@ -84,13 +84,13 @@ plotsituation <- function (x, nbid,outfic="plot_regression.pdf", outres="PreNorm
     for (p in 1:nbi) {# for each ion
         par (mfrow=c(ceiling((nbb+2)/3),3),ask=F,cex=1.2)
         labion=dimnames(x)[[2]][p+nbid]
-        indpool=which(x$sampleType=="pool") # QCpools subscripts in x 
+        indpool=which(x[[args$sample_type_col_name]]=="pool") # QCpools subscripts in x 
         pools1=x[indpool,p+nbid]; cv[p,1]=sd(pools1)/mean(pools1)# CV before correction
         for (b in 1:nbb) {# for each batch...
-            xb=data.frame(x[(x$batch==levels(x$batch)[b]),c(indtypsamp,indinject,p+nbid)])
-            indpb = which(xb$sampleType=="pool")# QCpools subscripts in the current batch
-            indsp = which(xb$sampleType=="sample")# samples subscripts in the current batch
-            indbt = which(xb$sampleType=="sample" | xb$sampleType=="pool")# indices de tous les samples d'un batch pools+samples  
+            xb=data.frame(x[(x[[args$batch_col_name]]==levels(x[[args$batch_col_name]])[b]),c(indtypsamp,indinject,p+nbid)])
+            indpb = which(xb[[args$sample_type_col_name]]=="pool")# QCpools subscripts in the current batch
+            indsp = which(xb[[args$sample_type_col_name]]=="sample")# samples subscripts in the current batch
+            indbt = which(xb[[args$sample_type_col_name]]=="sample" | xb[[args$sample_type_col_name]]=="pool")# indices de tous les samples d'un batch pools+samples  
             normLinearTest=ok_norm(xb[indpb,3],xb[indpb,2], xb[indsp,3],xb[indsp,2],method="linear")
             normLoessTest=ok_norm(xb[indpb,3],xb[indpb,2], xb[indsp,3],xb[indsp,2],method="loess")
             normLowessTest=ok_norm(xb[indpb,3],xb[indpb,2], xb[indsp,3],xb[indsp,2],method="lowess")
@@ -118,7 +118,7 @@ plotsituation <- function (x, nbid,outfic="plot_regression.pdf", outres="PreNorm
         }
 # series de plot avant et apres correction
 minval=min(x[p+nbid]);maxval=max(x[p+nbid])
-plot( x$injectionOrder, x[,p+nbid],col=x$batch,ylim=c(minval,maxval),ylab=labion,
+plot( x[[args$injection_order_col_name]], x[,p+nbid],col=x[[args$batch_col_name]],ylim=c(minval,maxval),ylab=labion,
       main=paste0("before correction (CV for pools = ",round(cv[p,1],2),")"))
 suppressWarnings(plot.design( x[c(indtypsamp,indbatch,indfact,p+nbid)],main="factors effect before correction"))
     }
@@ -141,9 +141,9 @@ normlowess=function (xb,detail="no",vref=1,b,span=NULL) {
   # vref : reference value (average of ion)
   # b : batch subscript
   # nbid: number of samples description columns (id and factors) with at least : "batch","injectionOrder","sampleType"
-  indpb = which(xb$sampleType=="pool") # pools subscripts of current batch
-  indsp = which(xb$sampleType=="sample") # samples of current batch subscripts
-  indbt = which(xb$sampleType=="sample" | xb$sampleType=="pool");# batch subscripts of all samples and QC-pools
+  indpb = which(xb[[args$sample_type_col_name]]=="pool") # pools subscripts of current batch
+  indsp = which(xb[[args$sample_type_col_name]]=="sample") # samples of current batch subscripts
+  indbt = which(xb[[args$sample_type_col_name]]=="sample" | xb[[args$sample_type_col_name]]=="pool");# batch subscripts of all samples and QC-pools
   labion=dimnames(xb)[[2]][3]
   newval=xb[[3]] # initialisation of corrected values = intial values
   ind <- 0 # initialisation of correction indicator
@@ -154,7 +154,7 @@ normlowess=function (xb,detail="no",vref=1,b,span=NULL) {
     reslowess=lowess(xb[indpb,2],xb[indpb,3],f=span2) # lowess regression with QC-pools 
     px=xb[indsp,2];  # vector of injectionOrder values only for samples  
     for(j in 1:length(indbt)) {	 
-      if (xb$sampleType[j]=="pool") {
+      if (xb[[args$sample_type_col_name]][j]=="pool") {
         if (reslowess$y[which(indpb==j)]==0) reslowess$y[which(indpb==j)] <- 1
         newval[j]=(vref*xb[j,3]) / (reslowess$y[which(indpb==j)])} 
       else { # for samples, the correction value cor correspond to the nearest QCpools 
@@ -190,9 +190,9 @@ normlinear <- function (xb,detail="no",vref=1,b,valneg=0) {
   # nbid: number of sample description columns (id and factors) with at least "batch", "injectionOrder" and "sampleType"
   # b: which batch it is
   # valneg: to determine what to do with generated negative and Inf values
-  indpb = which(xb$sampleType=="pool")# pools subscripts of current batch
-  indsp = which(xb$sampleType=="sample")# samples of current batch subscripts
-  indbt = which(xb$sampleType=="sample" | xb$sampleType=="pool") # QCpools and samples of current batch subscripts
+  indpb = which(xb[[args$sample_type_col_name]]=="pool")# pools subscripts of current batch
+  indsp = which(xb[[args$sample_type_col_name]]=="sample")# samples of current batch subscripts
+  indbt = which(xb[[args$sample_type_col_name]]=="sample" | xb[[args$sample_type_col_name]]=="pool") # QCpools and samples of current batch subscripts
   labion=dimnames(xb)[[2]][3]
   newval=xb[[3]] # initialisation of corrected values = intial values	
   ind <- 0 # initialisation of correction indicator
@@ -249,9 +249,9 @@ normloess <- function (xb,detail="no",vref=1,b,span=NULL) {
     #   detail : level of detail in the outlog file.
     #   vref : reference value (average of ion)
     #   b : batch subscript
-    indpb = which(xb$sampleType=="pool") # pools subscripts of current batch
-    indsp = which(xb$sampleType=="sample") # samples of current batch subscripts
-    indbt = which(xb$sampleType=="sample" | xb$sampleType=="pool");# batch subscripts of all samples and QCpools
+    indpb = which(xb[[args$sample_type_col_name]]=="pool") # pools subscripts of current batch
+    indsp = which(xb[[args$sample_type_col_name]]=="sample") # samples of current batch subscripts
+    indbt = which(xb[[args$sample_type_col_name]]=="sample" | xb[[args$sample_type_col_name]]=="pool");# batch subscripts of all samples and QCpools
     labion=dimnames(xb)[[2]][3]
     newval=xb[[3]] # initialisation of corrected values = intial values
     ind <- 0 # initialisation of correction indicator
@@ -302,15 +302,15 @@ norm_QCpool <- function (x, nbid, outlog, fact, metaion, detail="no", NormMoyPoo
   # method: regression method to be used to correct : "linear" or "lowess" or "loess"
   # valNull: to determine what to do with negatively estimated intensities
 	indfact		=which(dimnames(x)[[2]]==fact)
-	indtypsamp=which(dimnames(x)[[2]]=="sampleType")
-	indbatch	=which(dimnames(x)[[2]]=="batch")
-	indinject	=which(dimnames(x)[[2]]=="injectionOrder")
+	indtypsamp=which(dimnames(x)[[2]]==args$sample_type_col_name)
+	indbatch	=which(dimnames(x)[[2]]==args$batch_col_name)
+	indinject	=which(dimnames(x)[[2]]==args$injection_order_col_name)
 	lastIon=dim(x)[2]
 	valref=apply(as.matrix(x[,(nbid+1):(lastIon)]),2,mean) # reference value for each ion used to still have the same rought size of values
 	nbi=lastIon-nbid # number of ions
-	nbb=length(levels(x$batch)) # Number of batch(es) = number of levels of factor "batch" (can be =1)
-	nbs=length(x$sampleType[x$sampleType=="sample"])# Number of samples 
-	nbp=length(x$sampleType[x$sampleType=="pool"])# Number of QCpools
+	nbb=length(levels(x[[args$batch_col_name]])) # Number of batch(es) = number of levels of factor "batch" (can be =1)
+	nbs=length(x[[args$sample_type_col_name]][x[[args$sample_type_col_name]]=="sample"])# Number of samples 
+	nbp=length(x[[args$sample_type_col_name]][x[[args$sample_type_col_name]]=="pool"])# Number of QCpools
 	Xn=data.frame(x[,c(1:nbid)],matrix(0,nrow=nbp+nbs,ncol=nbi))# initialisation of the corrected dataframe (=initial dataframe)
   dimnames(Xn)=dimnames(x)
 	cv=data.frame(matrix(0,nrow=nbi,ncol=2))# initialisation of dataframe containing CV before and after correction
@@ -323,14 +323,14 @@ norm_QCpool <- function (x, nbid, outlog, fact, metaion, detail="no", NormMoyPoo
 	for (p in 1:nbi) {# for each ion
 	  labion=dimnames(x)[[2]][p+nbid]
         if (detail == "reg") {if(nbb<6){par(mfrow=c(3,3),ask=F,cex=1.5)}else{par(mfrow=c(4,4),ask=F,cex=1.5)}}
-		indpool=which(x$sampleType=="pool")# QCpools subscripts in all batches
+		indpool=which(x[[args$sample_type_col_name]]=="pool")# QCpools subscripts in all batches
 		pools1=x[indpool,p+nbid]; cv[p,1]=sd(pools1)/mean(pools1)# CV before correction
 		for (b in 1:nbb) {# for every batch
-			indpb = which(x$batch==levels(x$batch)[b] & x$sampleType=="pool")# QCpools subscripts of the current batch	
-			indsp = which(x$batch==levels(x$batch)[b] & x$sampleType=="sample")# samples subscripts of the current batch
-      indbt = which(x$batch==levels(x$batch)[b] & (x$sampleType=="pool" | x$sampleType=="sample")) # subscripts of all samples
+			indpb = which(x[[args$batch_col_name]]==levels(x[[args$batch_col_name]])[b] & x[[args$sample_type_col_name]]=="pool")# QCpools subscripts of the current batch	
+			indsp = which(x[[args$batch_col_name]]==levels(x[[args$batch_col_name]])[b] & x[[args$sample_type_col_name]]=="sample")# samples subscripts of the current batch
+      indbt = which(x[[args$batch_col_name]]==levels(x[[args$batch_col_name]])[b] & (x[[args$sample_type_col_name]]=="pool" | x[[args$sample_type_col_name]]=="sample")) # subscripts of all samples
       # cat(dimnames(x)[[2]][p+nbid]," indsp:",length(indsp)," indpb=",length(indpb)," indbt=",length(indbt)," ")
-			sub=data.frame(x[(x$batch==levels(x$batch)[b]),c(indtypsamp,indinject,p+nbid)])
+			sub=data.frame(x[(x[[args$batch_col_name]]==levels(x[[args$batch_col_name]])[b]),c(indtypsamp,indinject,p+nbid)])
 			if (method=="linear") { res.norm = normlinear(sub,detail,valref[p],b,valNull)
 			} else { if (method=="loess"){ res.norm <- normloess(sub,detail,valref[p],b,span)
 			  } else { if (method=="lowess"){ res.norm <- normlowess(sub,detail,valref[p],b,span)
@@ -353,12 +353,12 @@ norm_QCpool <- function (x, nbid, outlog, fact, metaion, detail="no", NormMoyPoo
 		if (detail=="reg" || detail=="plot" ) {
 		  	# plot before and after correction
 		  	minval=min(cbind(x[p+nbid],Xn[p+nbid]),na.rm=TRUE);maxval=max(cbind(x[p+nbid],Xn[p+nbid]),na.rm=TRUE)
-		  	plot( x$injectionOrder, x[,p+nbid],col=x$batch,ylab=labion,ylim=c(minval,maxval),
+		  	plot( x[[args$injection_order_col_name]], x[,p+nbid],col=x[[args$batch_col_name]],ylab=labion,ylim=c(minval,maxval),
               main=paste0("before correction (CV for pools = ",round(cv[p,1],2),")"))
-              points(x$injectionOrder[indpool],x[indpool,p+nbid],col="maroon",pch=".",cex=2)
-		  	plot(Xn$injectionOrder,Xn[,p+nbid],col=x$batch,ylab="",ylim=c(minval,maxval),
+              points(x[[args$injection_order_col_name]][indpool],x[indpool,p+nbid],col="maroon",pch=".",cex=2)
+		  	plot(Xn[[args$injection_order_col_name]],Xn[,p+nbid],col=x[[args$batch_col_name]],ylab="",ylim=c(minval,maxval),
              main=paste0("after correction (CV for pools = ",round(cv[p,2],2),")"))
-              points(Xn$injectionOrder[indpool],Xn[indpool,p+nbid],col="maroon",pch=".",cex=2)
+              points(Xn[[args$injection_order_col_name]][indpool],Xn[indpool,p+nbid],col="maroon",pch=".",cex=2)
 		  	suppressWarnings(plot.design( x[c(indtypsamp,indbatch,indfact,p+nbid)],main="factors effect before correction"))
 		  	suppressWarnings(plot.design(Xn[c(indtypsamp,indbatch,indfact,p+nbid)],main="factors effect after correction"))
 		}

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Status: [![Build Status](https://travis-ci.org/workflow4metabolomics/batchcorrec
 
 ### Description
 
-**Version:** 2.1.2  
-**Date:** 2017-04-30  
-**Author:** Jean-François Martin (INRA, AXIOM), Mélanie Pétéra (INRA, PFEM), Marion Landi (INRA, PFEM), Franck Giacomoni (INRA, PFEM), and Etienne A. Thévenot (CEA, LIST)  
+**Version:** 2.2.2  
+**Date:** 2018-06-16    
+**Author:** Jean-Fran?ois Martin (INRA, AXIOM), M?lanie P?t?ra (INRA, PFEM), Marion Landi (INRA, PFEM), Franck Giacomoni (INRA, PFEM), and Etienne A. Th?venot (CEA, LIST)  
 **Email:** [jean-francois.martin(at)toulouse.inra.fr](mailto:jean-francois.martin@toulouse.inra.frr), [melanie.petera(at)clermont.inra.fr](mailto:melanie.petera@clermont.inra.fr), [etienne.thevenot(at)cea.fr](mailto:etienne.thevenot@cea.fr)  
 **Citation:**  
 **Licence:** CeCILL  
@@ -75,6 +75,18 @@ See the reference histories [W4M00001_Sacurine-statistics; DOI:10.15454/1.481112
  
 
 ### News
+
+###### CHANGES IN VERSION 2.2.2  
+
+INTERNAL MODIFICATIONS  
+
+Fixed bug for color plot ("all_loess" methods)  
+
+###### CHANGES IN VERSION 2.2.0  
+
+NEW FEATURE  
+
+Specific names for the 'sampleType', 'injectionOrder', and 'batch' from sampleMetadata can be selected by the user (for compatibility with the MTBLS downloader)  
 
 ##### CHANGES IN VERSION 2.1.2  
 

--- a/batch_correction.Rproj
+++ b/batch_correction.Rproj
@@ -1,0 +1,13 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: knitr
+LaTeX: pdfLaTeX

--- a/batch_correction.xml
+++ b/batch_correction.xml
@@ -1,4 +1,4 @@
-<tool id="Batch_correction" name="Batch_correction" version="2.1.2">
+<tool id="Batch_correction" name="Batch_correction" version="2.2.0">
   <description>Corrects intensities for signal drift and batch-effects</description>
 
   <requirements>

--- a/batch_correction.xml
+++ b/batch_correction.xml
@@ -1,4 +1,4 @@
-<tool id="Batch_correction" name="Batch_correction" version="2.2.0">
+<tool id="Batch_correction" name="Batch_correction" version="2.2.2">
   <description>Corrects intensities for signal drift and batch-effects</description>
 
   <requirements>
@@ -313,6 +313,20 @@ See also the reference history:
 ----
 NEWS
 ----
+
+CHANGES IN VERSION 2.2.2  
+========================  
+
+INTERNAL MODIFICATIONS  
+
+Fixed bug for color plot ("all_loess" methods)  
+
+CHANGES IN VERSION 2.2.0  
+========================  
+
+NEW FEATURE  
+
+Specific names for the 'sampleType', 'injectionOrder', and 'batch' from sampleMetadata can be selected by the user (for compatibility with the MTBLS downloader)
 
 CHANGES IN VERSION 2.1.2  
 ========================  

--- a/batch_correction.xml
+++ b/batch_correction.xml
@@ -46,12 +46,17 @@
     #end if
     dataMatrix_out "$dataMatrix_out" variableMetadata_out "$variableMetadata_out"
     graph_output "$graph_output"  rdata_output "$rdata_output"
+    batch_col_name "$batch_col_name" injection_order_col_name "$injection_order_col_name" sample_type_col_name "$sample_type_col_name"
   ]]></command>
 
 	<inputs>
 		<param name="dataMatrix" label="Data Matrix file " format="tabular" type="data" />
 		<param name="sampleMetadata" label="Sample metadata file " format="tabular" type="data" help="must contain at least the three following columns: 'batch' + 'injectionOrder' + 'sampleType'"/>
 		<param name="variableMetadata" label="Variable metadata file " format="tabular" type="data" />
+
+		<param name="batch_col_name" label="Batch column name" type="text" size="64" value="batch" help="The name of the column containing the batch values."/>
+		<param name="injection_order_col_name" label="Injection order column name" type="text" size="64" value="injectionOrder" help="The name of the column containing the injection order values."/>
+		<param name="sample_type_col_name" label="Sample type column name" type="text" size="64" value="sampleType" help="The name of the column containing the sample type values."/>
 		
 		<conditional name="span_condition">
 			<param name="method" label="Type of regression model " type="select" help="To select between linear or non-linear (lowess or loess) methods to be used in Van der Kloet algorithm ; when using loess, you can choose to use pools or samples to model batch effect.">

--- a/batch_correction_all_loess_script.R
+++ b/batch_correction_all_loess_script.R
@@ -25,9 +25,10 @@ plotBatchF <- function(datMN, samDF.arg, spnN.arg) {
                    raw = "Raw",
                    nrm = "Normalized")
 
-    colVc <- c(sample = "green4",
+    colVc <- c(samp = "green4",
+               biol = "green4",
                pool = "red",
-               blank = "black",
+               blan = "black",
                other = "yellow")
 
     par(font = 2, font.axis = 2, font.lab = 2, lwd = 2, pch = 18)
@@ -37,7 +38,7 @@ plotBatchF <- function(datMN, samDF.arg, spnN.arg) {
 
     obsNamVc <- rownames(datMN)
 
-    obsColVc <- sapply(samDF.arg[, args$sample_type_col_name],
+    obsColVc <- sapply(substr(samDF.arg[, args$sample_type_col_name], 1, 4),
                        function(typC)
                        ifelse(typC %in% names(colVc), colVc[typC], colVc["other"]))
 
@@ -94,7 +95,7 @@ plotBatchF <- function(datMN, samDF.arg, spnN.arg) {
                   col = colVc["pool"])
         lines(batSeqVi,
               loessF(sumVn, batSamVi, batSeqVi, spnN=spnN.arg),
-              col = colVc["sample"])
+              col = colVc["samp"])
 
     }
 

--- a/batch_correction_all_loess_script.R
+++ b/batch_correction_all_loess_script.R
@@ -37,7 +37,7 @@ plotBatchF <- function(datMN, samDF.arg, spnN.arg) {
 
     obsNamVc <- rownames(datMN)
 
-    obsColVc <- sapply(samDF.arg[, "sampleType"],
+    obsColVc <- sapply(samDF.arg[, args$sample_type_col_name],
                        function(typC)
                        ifelse(typC %in% names(colVc), colVc[typC], colVc["other"]))
 
@@ -45,7 +45,7 @@ plotBatchF <- function(datMN, samDF.arg, spnN.arg) {
 
     par(mar = c(3.6, 3.6, 3.1, 0.6))
 
-    batTab <- table(samDF.arg[, "batch"])
+    batTab <- table(samDF.arg[, args$batch_col_name])
 
     sumVn <- rowSums(datMN, na.rm = TRUE)
 
@@ -83,11 +83,11 @@ plotBatchF <- function(datMN, samDF.arg, spnN.arg) {
 
     for(batC in names(batTab)) {
 
-        batSeqVi <- which(samDF.arg[, "batch"] == batC)
+        batSeqVi <- which(samDF.arg[, args$batch_col_name] == batC)
         batPooVi <- intersect(batSeqVi,
-                              grep("pool", samDF.arg[, "sampleType"]))
+                              grep("pool", samDF.arg[, args$sample_type_col_name]))
         batSamVi <- intersect(batSeqVi,
-                              grep("sample", samDF.arg[, "sampleType"]))
+                              grep("sample", samDF.arg[, args$sample_type_col_name]))
         if(length(batPooVi))
             lines(batSeqVi,
                   loessF(sumVn, batPooVi, batSeqVi, spnN=spnN.arg),
@@ -215,18 +215,18 @@ shiftBatchCorrectF <- function(rawMN.arg,
 
     ## computing median off all pools (or samples) for each variable
 
-    refMeaVn <- apply(rawMN.arg[samDF.arg[, "sampleType"] == refC.arg, ],
+    refMeaVn <- apply(rawMN.arg[samDF.arg[, args$sample_type_col_name] == refC.arg, ],
                       2,
                       function(feaRefVn) mean(feaRefVn, na.rm = TRUE))
 
     ## splitting data and sample metadata from each batch
 
     batRawLs <- split(as.data.frame(rawMN.arg),
-                      f = samDF.arg[, "batch"])
+                      f = samDF.arg[, args$batch_col_name])
     batRawLs <- lapply(batRawLs, function(inpDF) as.matrix(inpDF))
 
     batSamLs <- split(as.data.frame(samDF.arg),
-                      f = samDF.arg[, "batch"])
+                      f = samDF.arg[, args$batch_col_name])
 
     ## checking extrapolation: are there pools at the first and last observations of each batch
 
@@ -234,7 +234,7 @@ shiftBatchCorrectF <- function(rawMN.arg,
         pooExtML <- matrix(FALSE, nrow = 2, ncol = length(batRawLs),
                            dimnames = list(c("first", "last"), names(batRawLs)))
         for(batC in names(batSamLs)) {
-            batSamTypVc <- batSamLs[[batC]][, "sampleType"]
+            batSamTypVc <- batSamLs[[batC]][, args$sample_type_col_name]
             pooExtML["first", batC] <- head(batSamTypVc, 1) == "pool"
             pooExtML["last", batC] <- tail(batSamTypVc, 1) == "pool"
         }
@@ -263,7 +263,7 @@ shiftBatchCorrectF <- function(rawMN.arg,
 
         batAllVi <- 1:nrow(batRawMN)
 
-        batRefVi <- grep(refC.arg, batSamDF[, "sampleType"])
+        batRefVi <- grep(refC.arg, batSamDF[, args$sample_type_col_name])
 
         if(length(batRefVi) < 5)
             cat("\nWarning: less than 5 '", refC.arg, "'; linear regression will be performed instead of loess regression for this batch\n", sep="")

--- a/batch_correction_all_loess_wrapper.R
+++ b/batch_correction_all_loess_wrapper.R
@@ -1,7 +1,44 @@
 #!/usr/bin/env Rscript
 
 library(batch) ## necessary for parseCommandArgs function
+
+##------------------------------
+## test help option
+##------------------------------
+
+# Prog. constants
+argv.help <- commandArgs(trailingOnly = FALSE)
+script.path <- sub("--file=", "", argv.help[grep("--file=", argv.help)])
+prog.name <- basename(script.path)
+
+# Test Help
+if (length(grep('-h', argv.help)) > 0) {
+  cat("Usage: Rscript ", 
+    prog.name,
+    "{args} \n",
+    "parameters: \n",
+    "\tdataMatrix {file}: set the input data matrix file (mandatory) \n",
+    "\tsampleMetadata {file}: set the input sample metadata file (mandatory) \n",
+    "\tvariableMetadata {file}: set the input variable metadata file (mandatory) \n",
+    "\tmethod {opt}: set the method; can set to \"all_loess_pool\" or \"all_loess_sample\" (mandatory) \n",
+    "\tspan {condition}: set the span condition; (mandatory) \n",
+    "\tdataMatrix_out {file}: set the output data matrix file (mandatory) \n",
+    "\tvariableMetadata_out {file}: set the output variable metadata file (mandatory) \n",
+    "\tgraph_output {file}: set the output graph file (mandatory) \n",
+    "\trdata_output {file}: set the output Rdata file (mandatory) \n",
+    "\n")
+  quit(status = 0)
+}
+
+##------------------------------
+## init. params
+##------------------------------
+
 args = parseCommandArgs(evaluate=FALSE) #interpretation of arguments given in command line as an R list of objects
+
+##------------------------------
+## init. functions
+##------------------------------
 
 source_local <- function(fname){
     argv <- commandArgs(trailingOnly = FALSE)

--- a/batch_correction_all_loess_wrapper.R
+++ b/batch_correction_all_loess_wrapper.R
@@ -26,6 +26,9 @@ if (length(grep('-h', argv.help)) > 0) {
     "\tvariableMetadata_out {file}: set the output variable metadata file (mandatory) \n",
     "\tgraph_output {file}: set the output graph file (mandatory) \n",
     "\trdata_output {file}: set the output Rdata file (mandatory) \n",
+    "\tbatch_col_name {val}: the column name for batch. Default value is \"batch\".\n",
+    "\tinjection_order_col_name {val}: the column name for the injection order. Default value is \"injectionOrder\".\n",
+    "\tsample_type_col_name {val}: the column name for the sample types. Default value is \"sampleType\".\n",
     "\n")
   quit(status = 0)
 }
@@ -35,6 +38,14 @@ if (length(grep('-h', argv.help)) > 0) {
 ##------------------------------
 
 args = parseCommandArgs(evaluate=FALSE) #interpretation of arguments given in command line as an R list of objects
+
+# Set default col names
+if ( ! 'batch_col_name' %in% names(args))
+	args[['batch_col_name']] <- 'batch'
+if ( ! 'injection_order_col_name' %in% names(args))
+	args[['injection_order_col_name']] <- 'injectionOrder'
+if ( ! 'sample_type_col_name' %in% names(args))
+	args[['sample_type_col_name']] <- 'sampleType'
 
 ##------------------------------
 ## init. functions
@@ -118,10 +129,10 @@ spnN <- as.numeric(argVc["span"])
 stopifnot(refC %in% c("pool", "sample"))
 
 if(refC == "pool" &&
-   !any("pool" %in% samDF[, "sampleType"]))
+   !any("pool" %in% samDF[, args$sample_type_col_name]))
     stop("No 'pool' found in the 'sampleType' column; use the samples as normalization reference instead")
 
-refMN <- rawMN[samDF[, "sampleType"] == refC, ]
+refMN <- rawMN[samDF[, args$sample_type_col_name] == refC, ]
 refNasZerVl <- apply(refMN, 2,
                      function(refVn)
                      all(sapply(refVn,
@@ -146,7 +157,7 @@ if(sum(refNasZerVl)) {
 ##-------------------------------------
 
 samDF[, "ordIniVi"] <- 1:nrow(rawMN)
-ordBatInjVi <- order(samDF[, "batch"], samDF[, "injectionOrder"])
+ordBatInjVi <- order(samDF[, args$batch_col_name], samDF[, args$injection_order_col_name])
 rawMN <- rawMN[ordBatInjVi, ]
 samDF <- samDF[ordBatInjVi, ]
 

--- a/batch_correction_docker_wrapper.R
+++ b/batch_correction_docker_wrapper.R
@@ -1,0 +1,78 @@
+#!/usr/bin/Rscript --vanilla --slave --no-site-file
+
+################################################################################################
+# batch_correction_main_wrapper                                                                #
+#                                                                                              #
+# Author: Nils Paulhe                                                                          #
+# User: Galaxy                                                                                 #
+# Original data: --                                                                            #
+# Starting date: 2017-12-11                                                                    #
+# Version 1: 2017-12-11                                                                        #
+#                                                                                              #
+#                                                                                              #
+#                                                                                              #
+################################################################################################
+
+library(batch) #necessary for parseCommandArgs function
+
+##------------------------------
+## init. prog. constants
+##------------------------------
+
+argv.wrapper <- commandArgs(trailingOnly = FALSE)
+script.path <- sub("--file=", "", argv.wrapper[grep("--file=", argv.wrapper)])
+prog.name <- basename(script.path)
+
+##------------------------------
+## init. functions
+##------------------------------
+
+script_bypass <- function(other.script.name) {
+  initial.options <- commandArgs(trailingOnly = FALSE)
+  file.arg.name <- "--file="
+  script.name <- sub(file.arg.name, "", initial.options[grep(file.arg.name, initial.options)])
+  script.basename <- dirname(script.name)
+  other.script.fullpath <- paste(sep="/", script.basename, other.script.name)
+  # print(paste("calling", other.script.fullpath, "from", script.name))
+  other.script.cmd <- paste(sep=" ", "Rscript", other.script.fullpath, "-h")
+  system(other.script.cmd, wait=TRUE)
+}
+
+source_wrapper <- function(other.script.name){
+  initial.options <- commandArgs(trailingOnly = FALSE)
+  file.arg.name <- "--file="
+  script.name <- sub(file.arg.name, "", initial.options[grep(file.arg.name, initial.options)])
+  script.basename <- dirname(script.name)
+  other.script.fullpath <- paste(sep="/", script.basename, other.script.name)
+  #print(paste("calling", other.script.fullpath, "from", script.name))
+  source(other.script.fullpath)
+}
+
+##------------------------------
+## Test Help
+##------------------------------
+
+if (length(grep('-h', argv.wrapper)) > 0) {
+  cat("Usage: Rscript ", 
+    prog.name,
+    "{args} \n",
+    "parameters: \n",
+    "\t-h: display this help message, call all scripts with the same option and exit (optional) \n",
+    "\t--loess \"TRUE\": call the script as \"batch_correction_all_loess_wrapper.R\"; otherwise call it as \"batch_correction_wrapper.R\" one (optional) \n",
+    "for other parameters, please refer to each script specific options and parameters. \n",
+    "\n")
+  script_bypass("batch_correction_all_loess_wrapper.R")
+  script_bypass("batch_correction_wrapper.R")
+  quit(status = 0)
+}
+
+##------------------------------
+## check if loess or normal
+##------------------------------
+
+if (length(grep('--loess', argv.wrapper)) > 0) {
+  source_wrapper("batch_correction_all_loess_wrapper.R")
+} else {
+  source_wrapper("batch_correction_wrapper.R")
+}
+

--- a/batch_correction_wrapper.R
+++ b/batch_correction_wrapper.R
@@ -22,7 +22,47 @@
 
 
 library(batch) #necessary for parseCommandArgs function
+
+##------------------------------
+## test help option
+##------------------------------
+
+# Prog. constants
+argv.help <- commandArgs(trailingOnly = FALSE)
+script.path <- sub("--file=", "", argv.help[grep("--file=", argv.help)])
+prog.name <- basename(script.path)
+
+# Test Help
+if (length(grep('-h', argv.help)) > 0) {
+  cat("Usage: Rscript ", 
+    prog.name,
+    "{args} \n",
+    "parameters: \n",
+    "\tanalyse {val}: must be set to \"batch_correction\"",
+    "\tdataMatrix {file}: set the input data matrix file (mandatory) \n",
+    "\tsampleMetadata {file}: set the input sample metadata file (mandatory) \n",
+    "\tvariableMetadata {file}: set the input variable metadata file (mandatory) \n",
+    "\tmethod {opt}: set the method; can set to \"linear\", \"lowess\" or \"loess\" (mandatory) \n",
+    "\tspan {condition}: set the span condition; set to \"none\" if method is set to \"linear\" (mandatory) \n", 
+    "\tref_factor {value}: set the ref_factor value; (if span value is set to NULL, optional) \n",
+    "\tdetail {value}: set the detail value; (if span value is set to NULL, optional) \n",
+    "\tdataMatrix_out {file}: set the output data matrix file (mandatory) \n",
+    "\tvariableMetadata_out {file}: set the output variable metadata file (mandatory) \n",
+    "\tgraph_output {file}: set the output graph file (mandatory) \n",
+    "\trdata_output {file}: set the output Rdata file (mandatory) \n",
+    "\n")
+  quit(status = 0)
+}
+
+##------------------------------
+## init. params
+##------------------------------
+
 args = parseCommandArgs(evaluate=FALSE) #interpretation of arguments given in command line as an R list of objects
+
+##------------------------------
+## init. functions
+##------------------------------
 
 source_local <- function(...){
 	argv <- commandArgs(trailingOnly = FALSE)

--- a/test-batch_correction.sh
+++ b/test-batch_correction.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Set paths
+scriptdir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
+
+Rscript $scriptdir/batch_correction_docker_wrapper.R --loess "TRUE" dataMatrix "$scriptdir/test-data/input-batchcorrection-dataMatrix.tsv" sampleMetadata "$scriptdir/test-data/input-batchcorrection-sampleMetadata.tsv" variableMetadata "$scriptdir/test-data/input-batchcorrection-variableMetadata.tsv" method "all_loess_pool" span "1" dataMatrix_out "$scriptdir/output-batchcorrection-dataMatrix.tsv" variableMetadata_out "$scriptdir/output-batchcorrection-variableMetadata.tsv" graph_output "/tmp/test.pdf" rdata_output "/tmp/test.Rdata"   || exit 1
+
+diff $scriptdir/output-batchcorrection-dataMatrix.tsv $scriptdir/test-data/output-batchcorrection-dataMatrix.tsv || exit 2


### PR DESCRIPTION
Hi @melpetera ,

I've added the possibility to choose the three column names inside the tool.
The default names are the same names that were hardcoded, so it should break nothing.
I've been forced to do this modification in order to be able to run the tool on Metabolights studies where column names may vary (For MTBLS404/Sacurine the column names have been prefixed).

Tell me what you think and if you're ok with this change.

I've increase the tool version to 2.2.0, since the Galaxy tool XML has changed.