### PR TITLE
Pin the dependences' versions

### DIFF
--- a/batch_correction.xml
+++ b/batch_correction.xml
@@ -2,10 +2,10 @@
   <description>Corrects intensities for signal drift and batch-effects</description>
 
   <requirements>
-    <requirement type="package">r-batch</requirement>
-    <requirement type="package">r-ade4</requirement>
-    <requirement type="package">bioconductor-pcamethods</requirement>
-    <requirement type="package">bioconductor-ropls</requirement>
+    <requirement type="package" version="1.1_4">r-batch</requirement>
+    <requirement type="package" version="1.7_8">r-ade4</requirement>
+    <requirement type="package" version="1.70.0">bioconductor-pcamethods</requirement>
+    <requirement type="package" version="1.10.0">bioconductor-ropls</requirement>
   </requirements>
 
   <stdio>

--- a/build.xml
+++ b/build.xml
@@ -36,7 +36,7 @@
 			<arg value="--conda_prefix"/>
 			<arg value="${conda.dir}"/>
 			<arg value="--galaxy_branch"/>
-			<arg value="release_16.07"/>
+			<arg value="release_17.05"/>
 			<arg value="--conda_dependency_resolution"/>
 			<arg value="${tool.xml}"/>
 		</exec>

--- a/determine_bc.xml
+++ b/determine_bc.xml
@@ -2,9 +2,9 @@
   <description>to choose between linear, lowess and loess methods</description>
 
   <requirements>
-    <requirement type="package">r-batch</requirement>
-    <requirement type="package">r-ade4</requirement>
-    <requirement type="package">bioconductor-pcamethods</requirement>
+    <requirement type="package" version="1.1_4">r-batch</requirement>
+    <requirement type="package" version="1.7_8">r-ade4</requirement>
+    <requirement type="package" version="1.70.0">bioconductor-pcamethods</requirement>
   </requirements>
 
   <stdio>
@@ -38,6 +38,7 @@
         <when value="show">
             <param name="span" type="float" value="0.85" label="span" help="applied to lowess and loess regression"/>
         </when>
+        <when value="hide"/>
     </conditional>
   </inputs>
   


### PR DESCRIPTION
Otherwise, Conda will always take the laster one.
I also increase the Galaxy version to stick with the prod one